### PR TITLE
fixed xcode6 warnings

### DIFF
--- a/ios/UnityAds/UnityAdsCampaign/UnityAdsCampaignManager.h
+++ b/ios/UnityAds/UnityAdsCampaign/UnityAdsCampaignManager.h
@@ -34,6 +34,6 @@
 - (NSArray *)getViewableCampaigns;
 - (void)cacheNextCampaignAfter:(UnityAdsCampaign *)currentCampaign;
 
-+ (id)sharedInstance;
++ (instancetype)sharedInstance;
 
 @end

--- a/ios/UnityAds/UnityAdsCampaign/UnityAdsCampaignManager.m
+++ b/ios/UnityAds/UnityAdsCampaign/UnityAdsCampaignManager.m
@@ -26,7 +26,7 @@
 
 static UnityAdsCampaignManager *sharedUnityAdsInstanceCampaignManager = nil;
 
-+ (id)sharedInstance {
++ (instancetype)sharedInstance {
 	@synchronized(self) {
 		if (sharedUnityAdsInstanceCampaignManager == nil)
       sharedUnityAdsInstanceCampaignManager = [[UnityAdsCampaignManager alloc] init];

--- a/ios/UnityAds/UnityAdsInitializer/UnityAdsDefaultInitializer.h
+++ b/ios/UnityAds/UnityAdsInitializer/UnityAdsDefaultInitializer.h
@@ -8,6 +8,6 @@
 
 #import "UnityAdsInitializer.h"
 
-@interface UnityAdsDefaultInitializer : UnityAdsInitializer <UnityAdsCampaignManagerDelegate>
+@interface UnityAdsDefaultInitializer : UnityAdsInitializer <UnityAdsCampaignManagerDelegate, UnityAdsWebAppControllerDelegate>
 
 @end

--- a/ios/UnityAds/UnityAdsInitializer/UnityAdsInitializer.h
+++ b/ios/UnityAds/UnityAdsInitializer/UnityAdsInitializer.h
@@ -23,7 +23,7 @@
 - (void)initFailed;
 @end
 
-@interface UnityAdsInitializer : NSObject
+@interface UnityAdsInitializer : NSObject <UnityAdsCampaignManagerDelegate>
   @property (nonatomic, weak) id<UnityAdsInitializerDelegate> delegate;
   @property (nonatomic, strong) NSThread *backgroundThread;
   @property (nonatomic, assign) dispatch_queue_t queue;

--- a/ios/UnityAds/UnityAdsInitializer/UnityAdsInitializer.m
+++ b/ios/UnityAds/UnityAdsInitializer/UnityAdsInitializer.m
@@ -107,5 +107,20 @@
 	[[UnityAdsAnalyticsUploader sharedInstance] retryFailedUploads];
 }
 
+- (void)campaignManager:(UnityAdsCampaignManager *)campaignManager updatedWithCampaigns:(NSArray *)campaigns gamerID:(NSString *)gamerID
+{
+    
+}
+
+- (void)campaignManagerCampaignDataReceived
+{
+    
+}
+
+- (void)campaignManagerCampaignDataFailed
+{
+    
+}
+
 
 @end

--- a/ios/UnityAds/UnityAdsView/UnityAdsMainViewController.h
+++ b/ios/UnityAds/UnityAdsView/UnityAdsMainViewController.h
@@ -31,7 +31,7 @@
 @property (nonatomic, assign) BOOL isOpen;
 
 
-+ (id)sharedInstance;
++ (instancetype)sharedInstance;
 
 - (BOOL)openAds:(BOOL)animated inState:(UnityAdsViewStateType)requestedState withOptions:(NSDictionary *)options;
 - (BOOL)closeAds:(BOOL)forceMainThread withAnimations:(BOOL)animated withOptions:(NSDictionary *)options;

--- a/ios/UnityAds/UnityAdsView/UnityAdsMainViewController.m
+++ b/ios/UnityAds/UnityAdsView/UnityAdsMainViewController.m
@@ -300,7 +300,7 @@
 
 static UnityAdsMainViewController *sharedMainViewController = nil;
 
-+ (id)sharedInstance {
++ (instancetype)sharedInstance {
 	@synchronized(self) {
 		if (sharedMainViewController == nil) {
       sharedMainViewController = [[UnityAdsMainViewController alloc] initWithNibName:nil bundle:nil];

--- a/ios/UnityAds/UnityAdsWebView/UnityAdsWebAppController.h
+++ b/ios/UnityAds/UnityAdsWebView/UnityAdsWebAppController.h
@@ -30,5 +30,5 @@
 - (void)sendNativeEventToWebApp:(NSString *)eventType data:(NSDictionary *)data;
 - (void)initWebApp;
 
-+ (id)sharedInstance;
++ (instancetype)sharedInstance;
 @end

--- a/ios/UnityAds/UnityAdsWebView/UnityAdsWebAppController.m
+++ b/ios/UnityAds/UnityAdsWebView/UnityAdsWebAppController.m
@@ -33,7 +33,7 @@
 
 static UnityAdsWebAppController *sharedWebAppController = nil;
 
-+ (id)sharedInstance {
++ (instancetype)sharedInstance {
 	@synchronized(self) {
 		if (sharedWebAppController == nil) {
       sharedWebAppController = [[UnityAdsWebAppController alloc] init];


### PR DESCRIPTION
Changed the id to instancetype, which fixes some warnings in xcode 6 when compiling just for ios7+.  

Also added delegate protocol implementation to a few headers that were setting themselves as a delegate, however did not declare in the .h file that they in fact implemented that delegate, this also fixed warnings in xcode 6.

The class UnityAdsInitializer was setting itself as UnityAdsCampaignManagerDelegate, however didn't implement any of the protocol, which would result in a crash if that code ever ran.  I left the implementation empty because I'm not sure what should go there.
