### PR TITLE
UIWebView changes for VAST

### DIFF
--- a/ios/UnityAds/UnityAdsWebView/UnityAdsWebAppController.m
+++ b/ios/UnityAds/UnityAdsWebView/UnityAdsWebAppController.m
@@ -53,6 +53,8 @@ static UnityAdsWebAppController *sharedWebAppController = nil;
     self.webView.delegate = self;
     self.webView.autoresizingMask = UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight;
     self.webView.scalesPageToFit = NO;
+    self.webView.allowsInlineMediaPlayback = YES;
+    self.webView.mediaPlaybackRequiresUserAction = NO;
     [self.webView setBackgroundColor:[UIColor blackColor]];
     UIScrollView *scrollView = nil;
     


### PR DESCRIPTION
Vast for iPhone requires `allowsInlineMediaPlayback=YES` so that user would be able to
interact with video and click on it.

`mediaPlaybackRequiresUserAction=YES` is turned
on so that video would start automatically without user interaction

Both properties are available from iOS 4, so there should be no problem with compatability
