### PR TITLE
Sleep initCampaignManager for 3 seconds

### DIFF
--- a/ios/UnityAds/UnityAdsDevice/UnityAdsDevice.h
+++ b/ios/UnityAds/UnityAdsDevice/UnityAdsDevice.h
@@ -16,8 +16,8 @@
 + (NSString *)machineName;
 + (NSString *)analyticsMachineName;
 
-
-+ (NSCondition*)reachabilityCheck;
++ (NSCondition*)reachabilityCondition;
++ (void)launchReachabilityCheck;
 + (NSString *)currentConnectionType;
 
 + (NSString *)getNetworkType;

--- a/ios/UnityAds/UnityAdsDevice/UnityAdsDevice.h
+++ b/ios/UnityAds/UnityAdsDevice/UnityAdsDevice.h
@@ -17,8 +17,7 @@
 + (NSString *)analyticsMachineName;
 
 
-+ (void)launchReachabilityCheck;
-+ (void)clearReachabilityCheck;
++ (NSCondition*)reachabilityCheck;
 + (NSString *)currentConnectionType;
 
 + (NSString *)getNetworkType;

--- a/ios/UnityAds/UnityAdsDevice/UnityAdsDevice.m
+++ b/ios/UnityAds/UnityAdsDevice/UnityAdsDevice.m
@@ -331,7 +331,7 @@ static NSString* currentConnectionString = @"none";
 }
 
 + (void)launchReachabilityCheck {
-  static SCNetworkReachabilityRef reachabilityRef = NULL;
+  __block SCNetworkReachabilityRef reachabilityRef = NULL;
   
   void (^callbackBlock)(SCNetworkReachabilityFlags) = ^(SCNetworkReachabilityFlags flags) {    
     NSString* connectionString = noneConnectionString;
@@ -371,6 +371,10 @@ static NSString* currentConnectionString = @"none";
     currentConnectionString = connectionString;
     [[self reachabilityCondition] signal];
     [[self reachabilityCondition] unlock];
+    
+    SCNetworkReachabilitySetCallback(reachabilityRef, NULL, NULL);
+    SCNetworkReachabilitySetDispatchQueue(reachabilityRef, NULL);
+    reachabilityRef = NULL;
   };
 
   SCNetworkReachabilityContext context = {
@@ -389,7 +393,6 @@ static NSString* currentConnectionString = @"none";
 
 static void UnityAdsReachabilityCallback(SCNetworkReachabilityRef __unused ref, SCNetworkConnectionFlags flags, void* info) {
   void (^callbackBlock)(SCNetworkReachabilityFlags) = (__bridge id)info;
-  [NSThread sleepForTimeInterval:10.0];
   callbackBlock(flags);
 }
 

--- a/ios/UnityAds/UnityAdsDevice/UnityAdsDevice.m
+++ b/ios/UnityAds/UnityAdsDevice/UnityAdsDevice.m
@@ -317,62 +317,80 @@ int main(int argc, char *argv[]);
 	return [self _md5StringFromString:adId];
 }
 
-static NSString *wifiString = @"wifi";
-static NSString *cellularString = @"cellular";
-static NSString *connectionString = @"none";
+static NSString* wifiConnectionString = @"wifi";
+static NSString* cellularConnectionString = @"cellular";
+static NSString* noneConnectionString = @"none";
+static NSString* currentConnectionString = @"none";
 
-static void reachabilityCallBack(SCNetworkReachabilityRef reachabilityRef, SCNetworkReachabilityFlags flags, void * info) {
-  UAAssert(![NSThread isMainThread]);
-  if (reachabilityRef != NULL) {
-		SCNetworkReachabilityFlags flags;
-		if (SCNetworkReachabilityGetFlags(reachabilityRef, &flags)) {
-			if ((flags & kSCNetworkReachabilityFlagsConnectionRequired) == 0) {
-				// if target host is reachable and no connection is required
-				//  then we'll assume (for now) that you're on Wi-Fi
-				connectionString = wifiString;
-			}
-			
-			if ((flags & kSCNetworkReachabilityFlagsConnectionOnDemand) != 0 || (flags & kSCNetworkReachabilityFlagsConnectionOnTraffic) != 0)
-			{
-				// ... and the connection is on-demand (or on-traffic) if the
-				//     calling application is using the CFSocketStream or higher APIs
-				
-				if ((flags & kSCNetworkReachabilityFlagsInterventionRequired) == 0)
-				{
-					// ... and no [user] intervention is needed
-					connectionString = wifiString;
-				}
-			}
-			
-			if ((flags & kSCNetworkReachabilityFlagsIsWWAN) != 0)
-			{
-				// ... but WWAN connections are OK if the calling application
-				//     is using the CFNetwork (CFSocketStream?) APIs.
-				connectionString = cellularString;
-			}
++ (NSCondition*)reachabilityCheck {
+  static SCNetworkReachabilityRef reachabilityRef = NULL;
+  
+  NSCondition* condition = [NSCondition new];
+  
+  void (^callbackBlock)(SCNetworkReachabilityFlags) = ^(SCNetworkReachabilityFlags flags) {    
+    NSString* connectionString = noneConnectionString;
+    
+    if ((flags & kSCNetworkReachabilityFlagsConnectionRequired) == 0) {
+      // if target host is reachable and no connection is required
+      //  then we'll assume (for now) that you're on Wi-Fi
+      connectionString = wifiConnectionString;
+    }
+    
+    if ((flags & kSCNetworkReachabilityFlagsConnectionOnDemand) != 0 || (flags & kSCNetworkReachabilityFlagsConnectionOnTraffic) != 0)
+    {
+      // ... and the connection is on-demand (or on-traffic) if the
+      //     calling application is using the CFSocketStream or higher APIs
       
-			if ((flags & kSCNetworkReachabilityFlagsReachable) == 0)
-			{
-				// if target host is not reachable
-				connectionString = @"none";
-			}
-		}
+      if ((flags & kSCNetworkReachabilityFlagsInterventionRequired) == 0)
+      {
+        // ... and no [user] intervention is needed
+        connectionString = wifiConnectionString;
+      }
+    }
+    
+    if ((flags & kSCNetworkReachabilityFlagsIsWWAN) != 0)
+    {
+      // ... but WWAN connections are OK if the calling application
+      //     is using the CFNetwork (CFSocketStream?) APIs.
+      connectionString = cellularConnectionString;
+    }
+    
+    if ((flags & kSCNetworkReachabilityFlagsReachable) == 0)
+    {
+      // if target host is not reachable
+      connectionString = noneConnectionString;
+    }
+    
+    [condition lock];
+    currentConnectionString = connectionString;
+    [condition signal];
+    [condition unlock];
+  };
+
+  SCNetworkReachabilityContext context = {
+    .version = 0,
+    .info = (void *)CFBridgingRetain(callbackBlock),
+    .release = CFRelease
+  };
+
+  reachabilityRef = SCNetworkReachabilityCreateWithName(kCFAllocatorDefault, [@"unity3d.com" UTF8String]);
+  if (SCNetworkReachabilitySetCallback(reachabilityRef, UnityAdsReachabilityCallback, &context)){
+    if (!SCNetworkReachabilitySetDispatchQueue(reachabilityRef, dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0)) ){
+      SCNetworkReachabilitySetCallback(reachabilityRef, NULL, NULL);
+    }
   }
+  
+  return condition;
 }
 
-static SCNetworkReachabilityRef reachabilityRef = nil;
-
-+ (void)launchReachabilityCheck {
-  [self clearReachabilityCheck];
-  reachabilityRef = SCNetworkReachabilityCreateWithName(NULL, "unity3d.com");
-  SCNetworkReachabilitySetCallback(reachabilityRef, reachabilityCallBack, NULL);
-  SCNetworkReachabilitySetDispatchQueue(reachabilityRef, dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0));
+static void UnityAdsReachabilityCallback(SCNetworkReachabilityRef __unused ref, SCNetworkConnectionFlags flags, void* info) {
+  void (^callbackBlock)(SCNetworkReachabilityFlags) = (__bridge id)info;
+  callbackBlock(flags);
 }
 
-+ (void)clearReachabilityCheck {
-  if(reachabilityRef != NULL) {
-    CFRelease(reachabilityRef);
-    reachabilityRef = NULL;
++ (NSString*)currentConnectionType {
+  @synchronized(self) {
+    return currentConnectionString;
   }
 }
 
@@ -386,12 +404,6 @@ static SCNetworkReachabilityRef reachabilityRef = nil;
 #else
   return nil;
 #endif
-}
-  
-+ (NSString *)currentConnectionType {
-	@synchronized(self) {
-    return connectionString;
-  }
 }
 
 + (NSString *)softwareVersion {

--- a/ios/UnityAds/UnityAdsInitializer/UnityAdsInitializer.m
+++ b/ios/UnityAds/UnityAdsInitializer/UnityAdsInitializer.m
@@ -92,6 +92,10 @@
 	UAAssert(![NSThread isMainThread]);
 	UALOG_DEBUG(@"");
   [(UnityAdsCampaignManager *)[UnityAdsCampaignManager sharedInstance] setDelegate:self];
+  
+  // Hotfix: Allow time for connectionType to be determined before requesting ads.
+  [NSThread sleepForTimeInterval:3];
+  
 	[self refreshCampaignManager];
 }
 

--- a/ios/UnityAds/UnityAdsInitializer/UnityAdsInitializer.m
+++ b/ios/UnityAds/UnityAdsInitializer/UnityAdsInitializer.m
@@ -87,8 +87,9 @@
 }
 
 - (void)waitForReachabilityCheck {
-  NSCondition* condition = [UnityAdsDevice reachabilityCheck];
+  NSCondition* condition = [UnityAdsDevice reachabilityCondition];
   [condition lock];
+  [UnityAdsDevice launchReachabilityCheck];
   [condition waitUntilDate:[NSDate dateWithTimeIntervalSinceNow:5.0]];
   [condition unlock];
 }

--- a/ios/UnityAds/UnityAdsInitializer/UnityAdsInitializer.m
+++ b/ios/UnityAds/UnityAdsInitializer/UnityAdsInitializer.m
@@ -16,7 +16,6 @@
     [self createQueue];
   if (self.backgroundThread == nil)
     [self createBackgroundThread];
-  [UnityAdsDevice launchReachabilityCheck];
 }
 
 - (void)reInitialize {
@@ -56,7 +55,6 @@
 }
 
 - (void)dealloc {
-  [UnityAdsDevice clearReachabilityCheck];
   dispatch_release(self.queue);
 }
 
@@ -88,19 +86,23 @@
   }
 }
 
+- (void)waitForReachabilityCheck {
+  NSCondition* condition = [UnityAdsDevice reachabilityCheck];
+  [condition lock];
+  [condition waitUntilDate:[NSDate dateWithTimeIntervalSinceNow:5.0]];
+  [condition unlock];
+}
+
 - (void)initCampaignManager {
 	UAAssert(![NSThread isMainThread]);
 	UALOG_DEBUG(@"");
   [(UnityAdsCampaignManager *)[UnityAdsCampaignManager sharedInstance] setDelegate:self];
-  
-  // Hotfix: Allow time for connectionType to be determined before requesting ads.
-  [NSThread sleepForTimeInterval:3];
-  
 	[self refreshCampaignManager];
 }
 
 - (void)refreshCampaignManager {
 	UAAssert(![NSThread isMainThread]);
+  [self waitForReachabilityCheck];
 	[[UnityAdsProperties sharedInstance] refreshCampaignQueryString];
 	[[UnityAdsCampaignManager sharedInstance] updateCampaigns];
 }


### PR DESCRIPTION
Connection type is not determined before requesting ads; connectionType is none. Sleep the background thread to allow time for connectionType to be determined before requesting ads.