### PR TITLE
Send ready event only when webview init is completed

### DIFF
--- a/android/sources/src/com/unity3d/ads/android/UnityAds.java
+++ b/android/sources/src/com/unity3d/ads/android/UnityAds.java
@@ -486,9 +486,6 @@ public class UnityAds implements IUnityAdsCacheListener,
 		if (campaignHandler == null || campaignHandler.getCampaign() == null) return;
 
 		UnityAdsDeviceLog.debug(campaignHandler.getCampaign().toString());
-
-		if(hasViewableAds())
-			sendReadyEvent();
 	}
 
 	@Override


### PR DESCRIPTION
Android SDK used to send onFetchCompleted when campaign data was parsed but now SDK should send onFetchCompleted only after webview has been initialized (like iOS)
