### PR TITLE
Removed HTTP protocol check for catching commands from JS to native side

### DIFF
--- a/ios/UnityAds/UnityAdsURLProtocol/UnityAdsURLProtocol.m
+++ b/ios/UnityAds/UnityAdsURLProtocol/UnityAdsURLProtocol.m
@@ -16,11 +16,9 @@ static const NSString *kUnityAdsURLProtocolHostname = @"nativebridge.unityads.un
 + (BOOL)canInitWithRequest:(NSURLRequest *)request {
   NSURL *url = [request URL];
   
-  if ([[url scheme] isEqualToString:@"http"]) {
-    if ([[request HTTPMethod] isEqualToString:@"POST"] || [[request HTTPMethod] isEqualToString:@"OPTIONS"]) {
-      if ([[url host] isEqualToString:(NSString *)kUnityAdsURLProtocolHostname]) {
-        return TRUE;
-      }
+  if ([[request HTTPMethod] isEqualToString:@"POST"] || [[request HTTPMethod] isEqualToString:@"OPTIONS"]) {
+    if ([[url host] isEqualToString:(NSString *)kUnityAdsURLProtocolHostname]) {
+      return TRUE;
     }
   }
   


### PR DESCRIPTION
Starting from iOS9 we would move to HTTPS protocol
