### PR TITLE
Remove unused videos on iOS

### DIFF
--- a/ios/UnityAds/UnityAdsCampaign/UnityAdsCampaignManager.m
+++ b/ios/UnityAds/UnityAdsCampaign/UnityAdsCampaignManager.m
@@ -137,6 +137,28 @@ static UnityAdsCampaignManager *sharedUnityAdsInstanceCampaignManager = nil;
       NSString *gamerId = [jsonDictionary objectForKey:kUnityAdsGamerIDKey];
       
       [[UnityAdsProperties sharedInstance] setGamerId:gamerId];
+
+      NSError *error;
+      NSArray *files = [[NSFileManager defaultManager] contentsOfDirectoryAtPath:[[UnityAdsCacheManager sharedInstance] getCachePath] error:&error];
+      UALOG_DEBUG(@"Contents of path: %@", files);
+
+      [files enumerateObjectsUsingBlock:^(NSString *file, NSUInteger idx, BOOL *stop) {
+        UALOG_DEBUG(@"Current file: %@", file);
+        if ([self getCampaignWithVideoFile:file] == nil) {
+          UALOG_DEBUG(@"Should delete this file, not in campaigns: %@", [[[UnityAdsCacheManager sharedInstance] getCachePath] stringByAppendingPathComponent:file]);
+          NSError *error;
+          BOOL success = [[NSFileManager defaultManager] removeItemAtPath:[[[UnityAdsCacheManager sharedInstance] getCachePath] stringByAppendingPathComponent:file] error:&error];
+          if (!success) {
+            UALOG_DEBUG(@"Could not remove item at path: %@", [[[UnityAdsCacheManager sharedInstance] getCachePath] stringByAppendingPathComponent:file]);
+          }
+          else {
+            UALOG_DEBUG(@"Success removing item at path: %@", [[[UnityAdsCacheManager sharedInstance] getCachePath] stringByAppendingPathComponent:file]);
+          }
+        }
+        else {
+          UALOG_DEBUG(@"Video exists in current plan: %@", file);
+        }
+      }];
       
       [self.campaigns enumerateObjectsUsingBlock:^(UnityAdsCampaign *campaign, NSUInteger idx, BOOL *stop) {
         if ((campaign.shouldCacheVideo && campaign.allowedToCacheVideo) || (campaign.allowedToCacheVideo && idx == 0)) {
@@ -261,6 +283,16 @@ static UnityAdsCampaignManager *sharedUnityAdsInstanceCampaignManager = nil;
 	}
 	
 	return foundCampaign;
+}
+
+- (UnityAdsCampaign *)getCampaignWithVideoFile:(NSString *)videoFile {
+  for (UnityAdsCampaign *campaign in self.campaigns) {
+    if ([[[UnityAdsCacheManager sharedInstance] videoFilenameForCampaign:campaign] isEqualToString:videoFile]) {
+      return campaign;
+    }
+  }
+
+  return nil;
 }
 
 - (NSArray *)getViewableCampaigns {

--- a/ios/UnityAds/UnityAdsCampaign/UnityAdsCampaignManager.m
+++ b/ios/UnityAds/UnityAdsCampaign/UnityAdsCampaignManager.m
@@ -139,20 +139,22 @@ static UnityAdsCampaignManager *sharedUnityAdsInstanceCampaignManager = nil;
       [[UnityAdsProperties sharedInstance] setGamerId:gamerId];
 
       NSError *error;
-      NSArray *files = [[NSFileManager defaultManager] contentsOfDirectoryAtPath:[[UnityAdsCacheManager sharedInstance] getCachePath] error:&error];
+      NSString *cachePath = [[UnityAdsCacheManager sharedInstance] getCachePath];
+      NSArray *files = [[NSFileManager defaultManager] contentsOfDirectoryAtPath:cachePath error:&error];
       UALOG_DEBUG(@"Contents of path: %@", files);
 
       [files enumerateObjectsUsingBlock:^(NSString *file, NSUInteger idx, BOOL *stop) {
         UALOG_DEBUG(@"Current file: %@", file);
         if ([self getCampaignWithVideoFile:file] == nil) {
-          UALOG_DEBUG(@"Should delete this file, not in campaigns: %@", [[[UnityAdsCacheManager sharedInstance] getCachePath] stringByAppendingPathComponent:file]);
+          NSString *cacheFile = [cachePath stringByAppendingPathComponent:file];
+          UALOG_DEBUG(@"Should delete this file, not in campaigns: %@", cacheFile);
           NSError *error;
-          BOOL success = [[NSFileManager defaultManager] removeItemAtPath:[[[UnityAdsCacheManager sharedInstance] getCachePath] stringByAppendingPathComponent:file] error:&error];
+          BOOL success = [[NSFileManager defaultManager] removeItemAtPath:cacheFile error:&error];
           if (!success) {
-            UALOG_DEBUG(@"Could not remove item at path: %@", [[[UnityAdsCacheManager sharedInstance] getCachePath] stringByAppendingPathComponent:file]);
+            UALOG_DEBUG(@"Could not remove item at path: %@", cacheFile);
           }
           else {
-            UALOG_DEBUG(@"Success removing item at path: %@", [[[UnityAdsCacheManager sharedInstance] getCachePath] stringByAppendingPathComponent:file]);
+            UALOG_DEBUG(@"Success removing item at path: %@", cacheFile);
           }
         }
         else {

--- a/ios/UnityAds/UnityAdsData/UnityAdsCache/UnityAdsCacheManager.h
+++ b/ios/UnityAds/UnityAdsData/UnityAdsCache/UnityAdsCacheManager.h
@@ -27,12 +27,14 @@
 
 - (BOOL)cache:(ResourceType)resourceType forCampaign:(UnityAdsCampaign *)campaign;
 - (BOOL)campaignExistsInQueue:(UnityAdsCampaign *)campaign withResourceType:(ResourceType)resourceType;
+- (NSString *)videoFilenameForCampaign:(UnityAdsCampaign *)campaign;
 
 - (NSURL *)localURLFor:(ResourceType)resourceType ofCampaign:(UnityAdsCampaign *)campaign;
 - (BOOL)is:(ResourceType)resourceType cachedForCampaign:(UnityAdsCampaign *)campaign;
 
 - (void)cancelCacheForCampaign:(UnityAdsCampaign *)campaign withResourceType:(ResourceType)resourceType;
 - (void)cancelAllDownloads;
+- (NSString *)getCachePath;
 
 + sharedInstance;
 

--- a/ios/UnityAds/UnityAdsData/UnityAdsCache/UnityAdsCacheManager.m
+++ b/ios/UnityAds/UnityAdsData/UnityAdsCache/UnityAdsCacheManager.m
@@ -42,14 +42,14 @@ static UnityAdsCacheManager * _inst = nil;
 
 #pragma mark - Private
 
-- (NSString *)_cachePath {
+- (NSString *)getCachePath {
 	NSArray *paths = NSSearchPathForDirectoriesInDomains(NSCachesDirectory, NSUserDomainMask, YES);
 	UAAssertV(paths != nil && [paths count] > 0, nil);
 	
 	return [[paths objectAtIndex:0] stringByAppendingPathComponent:@"unityads"];
 }
 
-- (NSString *)_videoFilenameForCampaign:(UnityAdsCampaign *)campaign {
+- (NSString *)videoFilenameForCampaign:(UnityAdsCampaign *)campaign {
   if ([campaign.trailerDownloadableURL lastPathComponent] == nil || [campaign.trailerDownloadableURL lastPathComponent].length < 3) {
     return [NSString stringWithFormat:@"%@-%@", campaign.id, @"failed.mp4"];
   }
@@ -58,7 +58,7 @@ static UnityAdsCacheManager * _inst = nil;
 }
 
 - (NSString *)_videoPathForCampaign:(UnityAdsCampaign *)campaign {
-	return [[self _cachePath] stringByAppendingPathComponent:[self _videoFilenameForCampaign:campaign]];
+	return [[self getCachePath] stringByAppendingPathComponent:[self videoFilenameForCampaign:campaign]];
 }
 
 - (long long)_cachedFilesizeForVideoFilename:(NSString *)filename {
@@ -157,7 +157,7 @@ static UnityAdsCacheManager * _inst = nil;
     
     if (resourceType == ResourceTypeTrailerVideo) {
       UnityAdsCacheFileOperation  * tmp = [UnityAdsCacheFileOperation new];
-      tmp.directoryPath = [self _cachePath];
+      tmp.directoryPath = [self getCachePath];
       tmp.downloadURL = [self _downloadURLFor:resourceType of:campaign];
       tmp.filePath = [[self localURLFor:resourceType ofCampaign:campaign] relativePath];
       tmp.expectedFileSize = campaign.expectedTrailerSize;


### PR DESCRIPTION
Unused cached video have started to clutter devices since the caching logic was redone on iOS. This fix removes cached videos that are not used anymore.