### PR TITLE
Add comment about maxSdkVersion and manifest merges to AndroidManifes…

### DIFF
--- a/android/sources/AndroidManifest.xml
+++ b/android/sources/AndroidManifest.xml
@@ -13,5 +13,9 @@
     </application>
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
     <uses-permission android:name="android.permission.INTERNET" />
+
+    <!-- Note: If android:maxSdkVersion attribute leads to problems when merging manifests, you can
+         remove maxSdkVersion attribute. Unity Ads on Android 4.4 or later won't need this permission so
+         maxSdkVersion means it is only requested for older Androids. -->
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" android:maxSdkVersion="18" />
 </manifest>


### PR DESCRIPTION
It appears that android:maxSdkVersion attribute causes problems when merging with another manifest that has WRITE_EXTERNAL_STORAGE permission without the maxSdkVersion attribute. At least we can add a comment to our manifest about this issue. In the long term, I think we should figure out a way to use internal storage for older Androids and completely remove this permission. When doing the original investigation of this caching issue, I found out that video playback from internal storage may cause hard freezes on some Android 2.3 devices but these could be investigated further. For now, I think it's best to continue with this manifest and just add a comment.
