### PR TITLE
Fixes isSimulator function on iOS 9

### DIFF
--- a/ios/UnityAds/UnityAdsDevice/UnityAdsDevice.m
+++ b/ios/UnityAds/UnityAdsDevice/UnityAdsDevice.m
@@ -258,7 +258,7 @@ int main(int argc, char *argv[]);
     }
   }
 
-  return NO;
+  return NSProcessInfo.processInfo.environment[@"SIMULATOR_DEVICE_NAME"] != nil;
 }
 
 + (NSString *)analyticsMachineName {


### PR DESCRIPTION
iOS 9 changes behaviour of `[[UIDevice currentDevice] model]` and it doesn't return `simulator` suffix anymore. 

This pull request adds additional **runtime** check which works on iOS 9. It is OK to use [NSProcessInfo](http://nshipster.com/ios8/), we shouldn't get banned for that :)