### PR TITLE
Fix canShow status during onFetchCompleted callback

### DIFF
--- a/android/sources/src/com/unity3d/ads/android/view/UnityAdsMainView.java
+++ b/android/sources/src/com/unity3d/ads/android/view/UnityAdsMainView.java
@@ -137,8 +137,8 @@ public class UnityAdsMainView extends RelativeLayout {
 							public void run() {
 								if (!UnityAdsProperties.isAdsReadySent() && UnityAds.getListener() != null) {
 									UnityAdsDeviceLog.debug("Unity Ads ready.");
-									UnityAds.getListener().onFetchCompleted();
 									UnityAdsProperties.setAdsReadySent(true);
+									UnityAds.getListener().onFetchCompleted();
 								}
 							}
 						});


### PR DESCRIPTION
canShow always returns false during onFetchCompleted callback even though ads might actually be ready.
