### PR TITLE
Prefix strings.xml with unityads_

### DIFF
--- a/android/sources/res/layout/unityads_button_audio_toggle.xml
+++ b/android/sources/res/layout/unityads_button_audio_toggle.xml
@@ -63,7 +63,7 @@
         android:layout_height="wrap_content"
         android:textSize="15dp"
         android:textStyle="bold"
-        android:text="@string/mute_character"
+        android:text="@string/unityads_mute_character"
         android:textColor="#FFFFFFFF"
         android:layout_centerVertical="true"
         android:visibility="gone"

--- a/android/sources/res/layout/unityads_view_video_paused.xml
+++ b/android/sources/res/layout/unityads_view_video_paused.xml
@@ -21,6 +21,6 @@
         android:layout_alignParentBottom="true"
         android:layout_marginBottom="45dp"
         android:textColor="#FFFFFFFF"
-        android:text="@string/tap_to_continue"/>
+        android:text="@string/unityads_tap_to_continue"/>
 
 </RelativeLayout>

--- a/android/sources/res/layout/unityads_view_video_play.xml
+++ b/android/sources/res/layout/unityads_view_video_play.xml
@@ -44,7 +44,7 @@
         <TextView android:layout_width="wrap_content"
                   android:layout_height="wrap_content"
                   android:id="@+id/unityAdsVideoBufferingText"
-                  android:text="@string/buffering_text"
+                  android:text="@string/unityads_buffering_text"
                   android:textColor="@android:color/white"
                   android:padding="0dp"
                   android:layout_marginRight="3dp"
@@ -68,7 +68,7 @@
         <TextView android:layout_width="wrap_content"
                   android:layout_height="wrap_content"
                   android:id="@+id/unityAdsVideoTimeLeftPrefix"
-                  android:text="@string/video_end_prefix"
+                  android:text="@string/unityads_video_end_prefix"
                   android:textColor="@android:color/white"
                   android:padding="0dp"/>
 
@@ -83,7 +83,7 @@
         <TextView android:layout_width="wrap_content"
                   android:layout_height="wrap_content"
                   android:id="@+id/unityAdsVideoTimeLeftSuffix"
-                  android:text="@string/video_end_suffix"
+                  android:text="@string/unityads_video_end_suffix"
                   android:textColor="@android:color/white"
                   android:padding="0dp"/>
 

--- a/android/sources/res/values/strings.xml
+++ b/android/sources/res/values/strings.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="lib_name">Unity Ads</string>
-    <string name="tap_to_continue">Video paused. Tap screen to continue watching.</string>
-    <string name="mute_character">X</string>
-    <string name="buffering_text">Buffering&#8230;</string>
-    <string name="video_end_prefix">This video ends in </string>
-    <string name="video_end_suffix">seconds</string>
-    <string name="skip_video_prefix">You can skip this video in </string>
-    <string name="skip_video_suffix">seconds</string>
-    <string name="skip_video_text">Skip video</string>
-    <string name="default_video_length_text">00</string>
+    <string name="unityads_lib_name">Unity Ads</string>
+    <string name="unityads_tap_to_continue">Video paused. Tap screen to continue watching.</string>
+    <string name="unityads_mute_character">X</string>
+    <string name="unityads_buffering_text">Buffering&#8230;</string>
+    <string name="unityads_video_end_prefix">This video ends in </string>
+    <string name="unityads_video_end_suffix">seconds</string>
+    <string name="unityads_skip_video_prefix">You can skip this video in </string>
+    <string name="unityads_skip_video_suffix">seconds</string>
+    <string name="unityads_skip_video_text">Skip video</string>
+    <string name="unityads_default_video_length_text">00</string>
 </resources>

--- a/android/sources/src/com/unity3d/ads/android/video/UnityAdsVideoPlayView.java
+++ b/android/sources/src/com/unity3d/ads/android/video/UnityAdsVideoPlayView.java
@@ -255,7 +255,7 @@ public class UnityAdsVideoPlayView extends RelativeLayout {
 		_bufferingText = (TextView)_layout.findViewById(R.id.unityAdsVideoBufferingText);
 		_countDownText = (LinearLayout)_layout.findViewById(R.id.unityAdsVideoCountDown);
 		_timeLeftInSecondsText = (TextView)_layout.findViewById(R.id.unityAdsVideoTimeLeftText);
-		_timeLeftInSecondsText.setText(R.string.default_video_length_text);
+		_timeLeftInSecondsText.setText(R.string.unityads_default_video_length_text);
 		_skipTextView = (TextView)_layout.findViewById(R.id.unityAdsVideoSkipText);
 		_muteButton = new UnityAdsMuteVideoButton(getContext());
 		_muteButton.setLayout((RelativeLayout) _layout.findViewById(R.id.unityAdsAudioToggleView));
@@ -320,7 +320,7 @@ public class UnityAdsVideoPlayView extends RelativeLayout {
 		}
 
 		if (_skipTextView != null) {
-			_skipTextView.setText(R.string.skip_video_text);
+			_skipTextView.setText(R.string.unityads_skip_video_text);
 		}
 
 		if (_skipTextView != null) {
@@ -339,7 +339,7 @@ public class UnityAdsVideoPlayView extends RelativeLayout {
 			_skipTextView = (TextView) _layout.findViewById(R.id.unityAdsVideoSkipText);
 		}
 
-		_skipTextView.setText(getResources().getString(R.string.skip_video_prefix) + " " + skipTimeSeconds + " " + getResources().getString(R.string.skip_video_suffix));
+		_skipTextView.setText(getResources().getString(R.string.unityads_skip_video_prefix) + " " + skipTimeSeconds + " " + getResources().getString(R.string.unityads_skip_video_suffix));
 	}
 
 	private void updateTimeLeftText () {


### PR DESCRIPTION
Customer sent a report that they have bumped into a name collision problem because UnityAds strings.xml id's weren't prefixed with "unityads_"
