### PR TITLE
Spinner fix

### DIFF
--- a/ios/UnityAds/UnityAdsProperties/UnityAdsConstants.h
+++ b/ios/UnityAds/UnityAdsProperties/UnityAdsConstants.h
@@ -217,6 +217,11 @@ extern NSString * const kUnityAdsZoneMuteVideoSoundsKey;
 extern NSString * const kUnityAdsZoneUseDeviceOrientationForVideoKey;
 extern NSString * const kUnityAdsZoneAllowVideoSkipInSecondsKey;
 
+/* Errors */
+
+extern NSString * const kUnityAdsErrorDomain;
+extern int const kUnityAdsErrorTimeout;
+
 @interface UnityAdsConstants : NSObject
 
 @end

--- a/ios/UnityAds/UnityAdsProperties/UnityAdsConstants.m
+++ b/ios/UnityAds/UnityAdsProperties/UnityAdsConstants.m
@@ -206,6 +206,10 @@ NSString * const kUnityAdsZoneMuteVideoSoundsKey = @"muteVideoSounds";
 NSString * const kUnityAdsZoneUseDeviceOrientationForVideoKey = @"useDeviceOrientationForVideo";
 NSString * const kUnityAdsZoneAllowVideoSkipInSecondsKey = @"allowVideoSkipInSeconds";
 
+/* Errors */
+NSString * const kUnityAdsErrorDomain = @"com.unity.unityads";
+int const kUnityAdsErrorTimeout = -1;
+
 @implementation UnityAdsConstants
 
 @end


### PR DESCRIPTION
Fixes infinite spinner. Copy from [Trello card](http://trello.com/c/cHWpj2z7/136-end-page-spinner-never-got-hidden):

```
SKStoreProductViewControllerDelegate.loadProductWithParameters wouldn't call 
callback in case game iTunesID is not valid in user's AppStore (e.g. game not 
available in user's country)

In case user signed out from the AppStore (you can do it manually or in case device 
is new/updated to new iOS, think iOS 9) - default AppStore would be used (USA). 
Our server returns a game which available in this store. User sign in when requested 
to their own store - runs SKStoreProductViewControllerDelegate.loadProductWithParameters
again but callback would never got called
```

It's turned out there is no need to use any synchronisations primitives - both (timeout and store completion) blocks would be executed on the same `dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0)`, one after another, so just `BOOL` flag is enough. 

Tested in simulator (finally it works!), real device. Finally AppSheet works all the time, as previously it wasn't stable and sometimes cased infinite spinner.