### PR TITLE
Add proguard config to aar file

### DIFF
--- a/android/sources/build.gradle
+++ b/android/sources/build.gradle
@@ -35,4 +35,7 @@ android {
         sourceCompatibility JavaVersion.VERSION_1_7
         targetCompatibility JavaVersion.VERSION_1_7
     }
+    defaultConfig {
+        consumerProguardFiles 'proguard-project.txt'
+    }
 }


### PR DESCRIPTION
Currently generated .aar file lacks proguard config. This adds the config to aar library.
