### PR TITLE
Add missing minSdkVersion 9 to build.gradle

### DIFF
--- a/android/sources/build.gradle
+++ b/android/sources/build.gradle
@@ -36,6 +36,7 @@ android {
         targetCompatibility JavaVersion.VERSION_1_7
     }
     defaultConfig {
+        minSdkVersion 9
         consumerProguardFiles 'proguard-project.txt'
     }
 }


### PR DESCRIPTION
Without minSdkVersion 9 in build.gradle, Android Studio thinks the aar package is for API level 1 and adds WRITE_EXTERNAL_STORAGE, READ_PHONE_STATE and READ_EXTERNAL_STORAGE permissions to Android manifest for compatibility with API level 1.
