### PR TITLE
Fixed a crash in case the cache is not able to query for cached files…

### DIFF
--- a/android/sources/src/com/unity3d/ads/android/cache/UnityAdsCache.java
+++ b/android/sources/src/com/unity3d/ads/android/cache/UnityAdsCache.java
@@ -127,6 +127,11 @@ public class UnityAdsCache {
 			fileList = _cacheDirectory.listFiles(filter);
 		}
 
+		if(fileList == null) {
+			UnityAdsDeviceLog.error("Unity Ads cache: Could not obtain fileList from cache");
+			return;
+		}
+
 		for(File cacheFile : fileList) {
 			String name = cacheFile.getName();
 


### PR DESCRIPTION
… inside the cache folder.

In such a case - log the error and return before attempting to use the fileList (which might be null)
